### PR TITLE
Fix rendering of data

### DIFF
--- a/src/ScoreBoard.jsx
+++ b/src/ScoreBoard.jsx
@@ -14,7 +14,7 @@ export default function ScoreBoard() {
             }
         }
         fetchData();
-    });
+    }, [data]);
     return data ? (
         data.map((entry) => (
             <p key={entry.id}>{entry.player + " : " + entry.score}</p>


### PR DESCRIPTION
Specified data to only trigger re-rendering of scoreboard. This keeps the scoreboard from re-rendering indefinitely.